### PR TITLE
Translate text on complex source

### DIFF
--- a/lib/xlf-file-processor.js
+++ b/lib/xlf-file-processor.js
@@ -7,6 +7,7 @@ const async = require('async');
 const constants = require('./constants');
 const csvToJson = require("csvtojson");
 const xml2js = require('xml2js');
+const _ = require('lodash');
 
 function XlfFileProcessor() {
     // constructor
@@ -165,12 +166,18 @@ XlfFileProcessor.prototype.createCsvOutputFilesFromBody = function (path, bodies
         return {id: body.$.id, source: body.source[0], target: body.target[0]};
     });
 
+    translations.forEach((translation, index) => {
+    	if (!_.isString(translation.target)) {
+    		translation.target = translation.target["_"];
+		console.log(translation.target);
+	}
+    });
+
     const csvPath = [path, constants.CSV,
         `messages.${languageToTranslate}.${constants.CSV}`].join('/');
     const fields = ['id', 'source', 'target'];
     const json2csvParser = new Json2csvParser({fields});
     const csv = json2csvParser.parse(translations);
-
     fs.writeFile(csvPath, csv, (err) => {
         callback(err);
     });

--- a/lib/xlf-file-processor.js
+++ b/lib/xlf-file-processor.js
@@ -169,7 +169,6 @@ XlfFileProcessor.prototype.createCsvOutputFilesFromBody = function (path, bodies
     translations.forEach((translation, index) => {
     	if (!_.isString(translation.target)) {
     		translation.target = translation.target["_"];
-		console.log(translation.target);
 	}
     });
 

--- a/lib/xlf-processor.js
+++ b/lib/xlf-processor.js
@@ -7,6 +7,7 @@ const async = require('async');
 const chalk = require('chalk');
 const StringUtil = require('./utils/string.util');
 const logSymbols = require('log-symbols');
+const _ = require('lodash');
 
 function XlfProcessor() {
     // constructor;
@@ -380,11 +381,21 @@ XlfProcessor.prototype.validateAndChangeTargetsIfNeeded = function (file, callba
             });
 
             csvTranslationArray.forEach((translation, index) => {
-
                 const target = csvTranslationArray[index].target;
+
                 if (!messageTargets.includes(target)) {
                     if (messageTranslationArray[index]) {
-                        messageTranslationArray[index].target[0] = target;
+
+                    	if (_.isString(messageTranslationArray[index].target[0])) {
+                    		messageTranslationArray[index].target = target;
+                    	}
+                    	else {
+	                    	messageTranslationArray[index].target[0]['_'] = target;
+
+				var csvSource = JSON.parse(translation.source);
+				messageTranslationArray[index].source[0]['_'] = csvSource['_'];
+                    	}
+
                         totalMutated += 1;
                         console.log(chalk.yellow(`+++ ${target} for id ${messageTranslationArray[index].$.id}`));
                     } else {

--- a/lib/xlf-translator.js
+++ b/lib/xlf-translator.js
@@ -46,8 +46,8 @@ XlfTranslator.prototype.translateBody = function (bodies, fromLanguage, toLangua
 		}
 		else {
 			const newObj = _.cloneDeep(item.source[0]);
-			target = {target: newObj};
-			target.target['_'] = translatedString;
+			target = {target: [newObj]};
+			target.target[0]['_'] = [text];
 		}
                 translatedBody.push( Object.assign(target, item));
                 next();
@@ -59,8 +59,8 @@ XlfTranslator.prototype.translateBody = function (bodies, fromLanguage, toLangua
 		}
 		else {
 			const newObj = _.cloneDeep(item.source[0]);
-			target = {target: newObj};
-			target.target['_'] = translatedString;
+			target = {target: [newObj]};
+			target.target[0]['_'] = translatedString;
 		}
 
                 const newTranslatedItem = Object.assign(target, item);

--- a/lib/xlf-translator.js
+++ b/lib/xlf-translator.js
@@ -4,6 +4,7 @@ const translate = require('@k3rn31p4nic/google-translate-api');
 const errors = require('./errors');
 const StringUtil = require('./utils/string.util');
 const constants = require('./constants');
+const _ = require('lodash');
 
 function XlfTranslator() {
     // constructor
@@ -29,23 +30,47 @@ XlfTranslator.prototype.translateBody = function (bodies, fromLanguage, toLangua
     const translatedBody = [];
     async.eachLimit(bodies, 1, (item, next) => {
 
-        const text = StringUtil.sanitize(item.source[0]);
-        item.source[0] = text;
+        var text = "";
+
+	if (_.isString(item.source[0])) {
+	    text = StringUtil.sanitize(item.source[0]);
+	} else if (_.isObject(item.source[0]) && item.source[0]['_']) {
+	    text = item.source[0]['_'];
+	}
 
         this.translateString(text, fromLanguage, toLanguage, (err, translatedString) => {
             if (!translatedString) {
-                const target = {target: [text]};
+            	var target;
+		if (_.isString(item.source[0])) {
+			target = {target: [text]};
+		}
+		else {
+			const newObj = _.cloneDeep(item.source[0]);
+			target = {target: newObj};
+			target.target['_'] = translatedString;
+		}
                 translatedBody.push( Object.assign(target, item));
                 next();
             } else {
-                const target = {target: [translatedString]};
+            	var target;
+
+		if (_.isString(item.source[0])) {
+			target = {target: [translatedString]};
+		}
+		else {
+			const newObj = _.cloneDeep(item.source[0]);
+			target = {target: newObj};
+			target.target['_'] = translatedString;
+		}
+
                 const newTranslatedItem = Object.assign(target, item);
                 translatedBody.push(newTranslatedItem);
+
                 next(err);
             }
+           
         });
     }, (err) => {
-
         if (!translatedBody.length) {
             return callback(new Error(errors.COULD_NOT_TRANSLATE.description));
         }
@@ -84,7 +109,6 @@ XlfTranslator.prototype.translateString = function (string, fromLanguage, toLang
             }
             callback(null, res.text);
         }).catch((err) => {
-
         callback(err);
     });
 };


### PR DESCRIPTION
This utility will not attempt to translate complex <source> values, like this:

<source>{VAR_SELECT, select, male {male} female {female} other {other} }</source>
In this case, the utility will simply copy this element and rename it to <target>.

If this utility encounters something like this:
`<source>Is required <x id="ICU" equiv-text="{gender, select, male {...} female {...} other {...}}"/></source>`
only "Is required" will be translated.